### PR TITLE
avoid overrun of key.Key

### DIFF
--- a/bip32.go
+++ b/bip32.go
@@ -159,7 +159,7 @@ func (key *Key) getIntermediary(childIdx uint32) ([]byte, error) {
 		if key.IsPrivate {
 			data = publicKeyForPrivateKey(key.Key)
 		} else {
-			data = key.Key
+			data = append(data, key.Key...)
 		}
 	}
 	data = append(data, childIndexBytes...)


### PR DESCRIPTION
when generating intermediary, if key is public data is just assigned from key.Key and then modified. In some cases key.Key may be a slice over a larger array, and a buffer overrun may happen

